### PR TITLE
Drop --label flag from gh issue create command

### DIFF
--- a/create-github-issue/SKILL.md
+++ b/create-github-issue/SKILL.md
@@ -49,7 +49,7 @@ Use `gh issue create` with this template:
 
 Run:
 ```bash
-gh issue create --title "<title>" --body "<body>" --label "<category>"
+gh issue create --title "<title>" --body "<body>"
 ```
 
 ### 3. Confirm


### PR DESCRIPTION
## What

Removed `--label "<category>"` from the `gh issue create` command in `create-github-issue/SKILL.md`.

## Why

The `--label` flag errors when the label doesn't exist in the target repo, breaking the command for most repos.

Closes #2