### PR TITLE
Extract verbose content to REFERENCE.md to meet 100-line guideline

### DIFF
--- a/dep-audit/REFERENCE.md
+++ b/dep-audit/REFERENCE.md
@@ -1,0 +1,48 @@
+# Ecosystem-Specific Commands
+
+## Audit and outdated commands
+
+**Node (npm)**:
+```bash
+npm audit --json 2>/dev/null | head -200
+npm outdated --json 2>/dev/null | head -100
+```
+
+**Node (pnpm)**:
+```bash
+pnpm audit --json 2>/dev/null | head -200
+pnpm outdated --json 2>/dev/null | head -100
+```
+
+**Node (yarn)**:
+```bash
+yarn audit --json 2>/dev/null | head -200
+yarn outdated --json 2>/dev/null | head -100
+```
+
+**Python (pip)**:
+```bash
+pip audit --format=json 2>/dev/null | head -200
+pip list --outdated --format=json 2>/dev/null | head -100
+```
+
+**Rust (cargo)**:
+```bash
+cargo audit --json 2>/dev/null | head -200
+cargo outdated --format=json 2>/dev/null | head -100
+```
+
+**Go**:
+```bash
+go list -m -u -json all 2>/dev/null | head -200
+govulncheck ./... 2>/dev/null | head -100
+```
+
+## Update commands
+
+- **npm**: `npm install <package>@<version>`
+- **pnpm**: `pnpm update <package>@<version>`
+- **yarn**: `yarn upgrade <package>@<version>`
+- **pip**: `pip install <package>==<version>`
+- **cargo**: update version in `Cargo.toml`, then `cargo update -p <package>`
+- **go**: `go get <package>@<version>`

--- a/dep-audit/SKILL.md
+++ b/dep-audit/SKILL.md
@@ -21,45 +21,9 @@ If multiple are present (e.g. a monorepo), handle each ecosystem separately and 
 
 ### 2. Run audit and outdated commands
 
-Run the appropriate commands for each detected ecosystem. Capture output — do not stop on non-zero exit codes (audit commands return non-zero when vulnerabilities exist).
+Run the appropriate commands for each detected ecosystem. Capture output — do not stop on non-zero exit codes (audit commands return non-zero when vulnerabilities exist). If a tool is not installed, note it and skip — do not install tools.
 
-**Node (npm)**:
-```bash
-npm audit --json 2>/dev/null | head -200
-npm outdated --json 2>/dev/null | head -100
-```
-
-**Node (pnpm)**:
-```bash
-pnpm audit --json 2>/dev/null | head -200
-pnpm outdated --json 2>/dev/null | head -100
-```
-
-**Node (yarn)**:
-```bash
-yarn audit --json 2>/dev/null | head -200
-yarn outdated --json 2>/dev/null | head -100
-```
-
-**Python (pip)**:
-```bash
-pip audit --format=json 2>/dev/null | head -200
-pip list --outdated --format=json 2>/dev/null | head -100
-```
-
-**Rust (cargo)**:
-```bash
-cargo audit --json 2>/dev/null | head -200
-cargo outdated --format=json 2>/dev/null | head -100
-```
-
-**Go**:
-```bash
-go list -m -u -json all 2>/dev/null | head -200
-govulncheck ./... 2>/dev/null | head -100
-```
-
-If a tool is not installed (e.g. `pip audit`, `cargo audit`), note it in the output and skip — do not install tools.
+See [REFERENCE.md](REFERENCE.md) for ecosystem-specific commands.
 
 ### 3. Categorize findings
 
@@ -98,14 +62,7 @@ Ask: "Which should I update? (e.g. 1,2,6,7 or 'all safe' or 'all' or 'none')"
 
 ### 5. Apply selected updates
 
-Run the appropriate update command per ecosystem:
-
-- **npm**: `npm install <package>@<version>`
-- **pnpm**: `pnpm update <package>@<version>`
-- **yarn**: `yarn upgrade <package>@<version>`
-- **pip**: `pip install <package>==<version>`
-- **cargo**: update version in `Cargo.toml`, then `cargo update -p <package>`
-- **go**: `go get <package>@<version>`
+Run the appropriate update command per ecosystem. See [REFERENCE.md](REFERENCE.md) for ecosystem-specific commands.
 
 For major version bumps, check for a migration guide first and warn about known breaking changes before proceeding.
 

--- a/explain-codebase/REFERENCE.md
+++ b/explain-codebase/REFERENCE.md
@@ -1,0 +1,30 @@
+# Walkthrough Template
+
+```
+# [Project/Subsystem Name] — Developer Walkthrough
+
+## Purpose
+[2-3 sentences: what this does and why it exists]
+
+## Architecture Overview
+[High-level structure. Name major components and how they relate.]
+
+## Key Files
+| File | Role |
+|---|---|
+| `src/index.ts` | Application entry point |
+| `src/routes/` | Route definitions |
+| ... | ... |
+
+## Data Flow
+[Walk through a concrete example: "When a user logs in..."
+Trace the request from entry point through each layer.]
+
+## Conventions
+- **Errors**: [how errors are handled]
+- **Testing**: [where tests live, how to run them]
+- **Naming**: [file naming, function naming patterns]
+
+## Where to Start
+[Which files to read first, in what order, and what to try modifying.]
+```

--- a/explain-codebase/SKILL.md
+++ b/explain-codebase/SKILL.md
@@ -72,36 +72,7 @@ Note patterns a new developer needs to follow:
 
 ### 6. Generate the walkthrough
 
-Present the walkthrough in this structure:
-
-```
-# [Project/Subsystem Name] — Developer Walkthrough
-
-## Purpose
-[2-3 sentences: what this does and why it exists]
-
-## Architecture Overview
-[High-level structure. Name major components and how they relate.]
-
-## Key Files
-| File | Role |
-|---|---|
-| `src/index.ts` | Application entry point |
-| `src/routes/` | Route definitions |
-| ... | ... |
-
-## Data Flow
-[Walk through a concrete example: "When a user logs in..."
-Trace the request from entry point through each layer.]
-
-## Conventions
-- **Errors**: [how errors are handled]
-- **Testing**: [where tests live, how to run them]
-- **Naming**: [file naming, function naming patterns]
-
-## Where to Start
-[Which files to read first, in what order, and what to try modifying.]
-```
+Present the walkthrough using the template in [REFERENCE.md](REFERENCE.md). Sections: Purpose, Architecture Overview, Key Files, Data Flow, Conventions, Where to Start.
 
 ### 7. Deliver output
 

--- a/find-fixes/REFERENCE.md
+++ b/find-fixes/REFERENCE.md
@@ -1,0 +1,74 @@
+# Search Patterns by Category
+
+## Dead code
+
+**Unused exports** — find exports then check if anything imports them:
+```bash
+# Find all named exports
+grep -rn "^export " src/ --include="*.ts" --include="*.tsx"
+
+# For each symbol found, check if it's imported anywhere
+grep -rn "symbolName" src/ --include="*.ts" --include="*.tsx"
+```
+A symbol is dead if the only match is its own definition.
+
+**Commented-out code** — look for code-shaped comments:
+```bash
+grep -rn "^[[:space:]]*//" src/ --include="*.ts" --include="*.tsx" | grep -E "(const|let|var|function|return|if|import)"
+```
+
+**Unreachable branches:**
+```bash
+grep -rn "if (false\|if(false" src/ --include="*.ts" --include="*.tsx"
+```
+
+## TypeScript
+
+**`any` usage:**
+```bash
+grep -rn ": any\b\|as any\b\|<any>" src/ --include="*.ts" --include="*.tsx"
+```
+Only flag `any` where the correct type is obvious from surrounding context. Skip if it's genuinely hard to type.
+
+**Suppression comments:**
+```bash
+grep -rn "@ts-ignore\|@ts-expect-error" src/ --include="*.ts" --include="*.tsx"
+```
+Check each one — if the error it suppresses no longer exists (i.e. removing the comment causes no error), it's dead.
+
+**Type assertions that should be narrowing:**
+```bash
+grep -rn " as [A-Z]\w*" src/ --include="*.ts" --include="*.tsx"
+```
+Flag assertions where a type guard or proper narrowing is clearly the right fix.
+
+## Code smells
+
+**Magic values used more than once:**
+```bash
+# Magic numbers
+grep -rn "[^a-zA-Z][0-9]\{2,\}[^0-9]" src/ --include="*.ts" --include="*.tsx" | grep -v "test\|spec\|\.d\.ts"
+
+# Magic strings (look for repeated string literals)
+grep -roh '"[a-zA-Z][a-zA-Z_-]\{4,\}"' src/ --include="*.ts" --include="*.tsx" | sort | uniq -d
+```
+
+**Copy-pasted blocks** — look for identical multi-line patterns by reading files that are structurally similar to each other (same directory, same naming pattern). If two files have near-identical sections of 10+ lines, flag it.
+
+## Standard deviations
+
+This category requires establishing the convention first.
+
+For each of these, read enough files to determine the project standard, then search for outliers:
+
+- **Error handling**: Is it `try/catch`, `Result` types, or `.catch()`? Search for the minority pattern.
+- **Async style**: Is it `async/await` or `.then()`? Search for `.then(` if async/await dominates.
+- **Import style**: Named imports, default imports, or barrel imports? Search for the outlier pattern.
+- **Naming**: camelCase functions, PascalCase types — search for violations:
+  ```bash
+  # Functions that start with uppercase (should be PascalCase components or classes only)
+  grep -rn "^export function [A-Z]" src/ --include="*.ts"
+
+  # Types/interfaces that start with lowercase
+  grep -rn "^export type [a-z]\|^export interface [a-z]" src/ --include="*.ts"
+  ```

--- a/find-fixes/SKILL.md
+++ b/find-fixes/SKILL.md
@@ -40,90 +40,11 @@ Tool output is authoritative. Flag anything surfaced here as a finding — these
 
 ### 3. Scan for fixes by category
 
-Work through each category using the search strategies below. For each finding, verify it's real before adding it to your list.
+Work through each category. For each finding, verify it's real before adding it to your list.
 
----
+Categories: **Dead code**, **TypeScript**, **Code smells**, **Standard deviations**.
 
-#### Dead code
-
-**Unused exports** — find exports then check if anything imports them:
-```bash
-# Find all named exports
-grep -rn "^export " src/ --include="*.ts" --include="*.tsx"
-
-# For each symbol found, check if it's imported anywhere
-grep -rn "symbolName" src/ --include="*.ts" --include="*.tsx"
-```
-A symbol is dead if the only match is its own definition.
-
-**Commented-out code** — look for code-shaped comments:
-```bash
-grep -rn "^[[:space:]]*//" src/ --include="*.ts" --include="*.tsx" | grep -E "(const|let|var|function|return|if|import)"
-```
-
-**Unreachable branches:**
-```bash
-grep -rn "if (false\|if(false" src/ --include="*.ts" --include="*.tsx"
-```
-
----
-
-#### TypeScript
-
-**`any` usage:**
-```bash
-grep -rn ": any\b\|as any\b\|<any>" src/ --include="*.ts" --include="*.tsx"
-```
-Only flag `any` where the correct type is obvious from surrounding context. Skip if it's genuinely hard to type.
-
-**Suppression comments:**
-```bash
-grep -rn "@ts-ignore\|@ts-expect-error" src/ --include="*.ts" --include="*.tsx"
-```
-Check each one — if the error it suppresses no longer exists (i.e. removing the comment causes no error), it's dead.
-
-**Type assertions that should be narrowing:**
-```bash
-grep -rn " as [A-Z]\w*" src/ --include="*.ts" --include="*.tsx"
-```
-Flag assertions where a type guard or proper narrowing is clearly the right fix.
-
----
-
-#### Code smells
-
-**Magic values used more than once:**
-```bash
-# Magic numbers
-grep -rn "[^a-zA-Z][0-9]\{2,\}[^0-9]" src/ --include="*.ts" --include="*.tsx" | grep -v "test\|spec\|\.d\.ts"
-
-# Magic strings (look for repeated string literals)
-grep -roh '"[a-zA-Z][a-zA-Z_-]\{4,\}"' src/ --include="*.ts" --include="*.tsx" | sort | uniq -d
-```
-
-**Copy-pasted blocks** — look for identical multi-line patterns by reading files that are structurally similar to each other (same directory, same naming pattern). If two files have near-identical sections of 10+ lines, flag it.
-
----
-
-#### Standard deviations
-
-This category requires establishing the convention first.
-
-For each of these, read enough files to determine the project standard, then search for outliers:
-
-- **Error handling**: Is it `try/catch`, `Result` types, or `.catch()`? Search for the minority pattern.
-- **Async style**: Is it `async/await` or `.then()`? Search for `.then(` if async/await dominates.
-- **Import style**: Named imports, default imports, or barrel imports? Search for the outlier pattern.
-- **Naming**: camelCase functions, PascalCase types — search for violations:
-  ```bash
-  # Functions that start with uppercase (should be PascalCase components or classes only)
-  grep -rn "^export function [A-Z]" src/ --include="*.ts"
-
-  # Types/interfaces that start with lowercase
-  grep -rn "^export type [a-z]\|^export interface [a-z]" src/ --include="*.ts"
-  ```
-
----
+See [REFERENCE.md](REFERENCE.md) for search patterns and grep commands per category.
 
 ### 4. Rejection criteria
 

--- a/pr-review/REFERENCE.md
+++ b/pr-review/REFERENCE.md
@@ -1,0 +1,42 @@
+# Review Criteria
+
+| Area | What to look for |
+|---|---|
+| **Correctness** | Logic errors, off-by-one, wrong variable, missing return, race conditions |
+| **Edge cases** | Null/undefined inputs, empty arrays, boundary values, error paths |
+| **Security** | Injection, auth bypass, secrets in code, unsafe deserialization, XSS |
+| **Breaking changes** | Changed public API, renamed exports, removed fields, altered behavior |
+| **Test coverage** | New logic without tests, changed behavior without updated tests |
+| **Clarity** | Confusing naming, missing comments on non-obvious logic, dead code in diff |
+
+Do NOT flag:
+- Style issues already covered by linters (formatting, semicolons, quote style)
+- Patterns consistent with the rest of the codebase, even if you would do it differently
+- TODOs explicitly marked as follow-up work in the PR description
+
+# Output Template
+
+```
+## PR Review: <PR title> (#<number>)
+
+**Summary**: [1-2 sentence overall assessment]
+
+### Blocking
+Issues that must be fixed before merge.
+
+1. **[Correctness]** `src/handler.ts:42` — Error response returns 200 instead of 400.
+2. **[Security]** `src/auth.ts:15` — User input passed directly to SQL query.
+
+### Suggestions
+Improvements worth making but not blocking.
+
+3. **[Edge case]** `src/utils.ts:78` — `parseDate` does not handle empty string.
+4. **[Test coverage]** — No tests for the new `/api/reset` endpoint.
+
+### Nits
+Minor observations, take or leave.
+
+5. **[Clarity]** `src/handler.ts:30` — `data` is vague; consider `validatedPayload`.
+```
+
+If there are no findings in a severity group, omit that group.

--- a/pr-review/SKILL.md
+++ b/pr-review/SKILL.md
@@ -43,50 +43,11 @@ For each file in the diff, read the full file (not just the diff hunks) to under
 
 ### 4. Review the changes
 
-Evaluate every change against these criteria:
-
-| Area | What to look for |
-|---|---|
-| **Correctness** | Logic errors, off-by-one, wrong variable, missing return, race conditions |
-| **Edge cases** | Null/undefined inputs, empty arrays, boundary values, error paths |
-| **Security** | Injection, auth bypass, secrets in code, unsafe deserialization, XSS |
-| **Breaking changes** | Changed public API, renamed exports, removed fields, altered behavior |
-| **Test coverage** | New logic without tests, changed behavior without updated tests |
-| **Clarity** | Confusing naming, missing comments on non-obvious logic, dead code in diff |
-
-Do NOT flag:
-- Style issues already covered by linters (formatting, semicolons, quote style)
-- Patterns consistent with the rest of the codebase, even if you would do it differently
-- TODOs explicitly marked as follow-up work in the PR description
+Evaluate every change against the criteria in [REFERENCE.md](REFERENCE.md): correctness, edge cases, security, breaking changes, test coverage, clarity.
 
 ### 5. Present the review
 
-Group findings by severity:
-
-```
-## PR Review: <PR title> (#<number>)
-
-**Summary**: [1-2 sentence overall assessment]
-
-### Blocking
-Issues that must be fixed before merge.
-
-1. **[Correctness]** `src/handler.ts:42` — Error response returns 200 instead of 400.
-2. **[Security]** `src/auth.ts:15` — User input passed directly to SQL query.
-
-### Suggestions
-Improvements worth making but not blocking.
-
-3. **[Edge case]** `src/utils.ts:78` — `parseDate` does not handle empty string.
-4. **[Test coverage]** — No tests for the new `/api/reset` endpoint.
-
-### Nits
-Minor observations, take or leave.
-
-5. **[Clarity]** `src/handler.ts:30` — `data` is vague; consider `validatedPayload`.
-```
-
-If there are no findings in a severity group, omit that group.
+Group findings by severity (Blocking / Suggestions / Nits) using the output template in [REFERENCE.md](REFERENCE.md). Omit empty severity groups.
 
 Ask: "Should I post this review to GitHub? (yes / yes with line comments / no)"
 

--- a/write-a-skill/REFERENCE.md
+++ b/write-a-skill/REFERENCE.md
@@ -1,0 +1,40 @@
+# Description Requirements
+
+The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+
+**Goal**: Give your agent just enough info to know:
+
+1. What capability this skill provides
+2. When/why to trigger it (specific keywords, contexts, file types)
+
+**Format**:
+
+- Max 1024 chars
+- Write in third person
+- First sentence: what it does
+- Second sentence: "Use when [specific triggers]"
+
+**Good example**:
+
+```
+Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
+```
+
+**Bad example**:
+
+```
+Helps with documents.
+```
+
+The bad example gives your agent no way to distinguish this from other document skills.
+
+# Review Checklist
+
+After drafting, verify:
+
+- [ ] Description includes triggers ("Use when...")
+- [ ] SKILL.md under 100 lines
+- [ ] No time-sensitive info
+- [ ] Consistent terminology
+- [ ] Concrete examples included
+- [ ] References one level deep

--- a/write-a-skill/SKILL.md
+++ b/write-a-skill/SKILL.md
@@ -59,59 +59,14 @@ description: Brief description of capability. Use when [specific triggers].
 
 ## Description Requirements
 
-The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+See [REFERENCE.md](REFERENCE.md) for full description format, examples, and the review checklist.
 
-**Goal**: Give your agent just enough info to know:
-
-1. What capability this skill provides
-2. When/why to trigger it (specific keywords, contexts, file types)
-
-**Format**:
-
-- Max 1024 chars
-- Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
-
-**Good example**:
-
-```
-Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
-```
-
-**Bad example**:
-
-```
-Helps with documents.
-```
-
-The bad example gives your agent no way to distinguish this from other document skills.
+Key rules: max 1024 chars, third person, first sentence = what it does, second = "Use when [triggers]".
 
 ## When to Add Scripts
 
-Add utility scripts when:
-
-- Operation is deterministic (validation, formatting)
-- Same code would be generated repeatedly
-- Errors need explicit handling
-
-Scripts save tokens and improve reliability vs generated code.
+Add utility scripts when the operation is deterministic (validation, formatting), would be generated repeatedly, or needs explicit error handling.
 
 ## When to Split Files
 
-Split into separate files when:
-
-- SKILL.md exceeds 100 lines
-- Content has distinct domains (finance vs sales schemas)
-- Advanced features are rarely needed
-
-## Review Checklist
-
-After drafting, verify:
-
-- [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
-- [ ] No time-sensitive info
-- [ ] Consistent terminology
-- [ ] Concrete examples included
-- [ ] References one level deep
+Split into separate files when SKILL.md exceeds 100 lines, content has distinct domains, or advanced features are rarely needed.


### PR DESCRIPTION
## What

Moved ecosystem commands, search patterns, review criteria, output templates, and description requirements from SKILL.md into REFERENCE.md files for 5 skills (dep-audit, explain-codebase, find-fixes, pr-review, write-a-skill).

## Why

All 5 skills exceeded the 100-line SKILL.md guideline defined in write-a-skill. After extraction, all are under 100 lines (72–82).

Closes #6, closes #7, closes #8, closes #9, closes #10